### PR TITLE
[PKG-2617] sphinx-sitemap 2.5.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,41 +1,49 @@
+{% set name = "sphinx-sitemap" %}
 {% set version = "2.5.1" %}
 
 package:
-  name: sphinx-sitemap
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/s/sphinx-sitemap/sphinx-sitemap-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 984bef068bbdbc26cfae209a8b61392e9681abc9191b477cd30da406e3a60ee5
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv --no-deps
+  skip: True  # [py<37]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
     - pip
-    - python >=2.7
+    - python
+    - setuptools
+    - wheel
   run:
-    - python >=2.7
+    - python
     - six
     - sphinx >=1.2
 
 test:
   imports:
     - sphinx_sitemap
-  commands:
-    - pip check
   requires:
     - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/jdillard/sphinx-sitemap
+  dev_url: https://github.com/jdillard/sphinx-sitemap
+  doc_url: https://sphinx-sitemap.readthedocs.io/
   summary: Sitemap generator for Sphinx
+  description: |
+    A Sphinx extension to generate multi-version and multi-language sitemaps.org compliant sitemaps 
+    for the HTML version of your Sphinx documentation.
   license: MIT
+  license_family: MIT
   license_file: LICENSE
-  doc_url: https://sphinx-sitemap.readthedocs.io
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Changelog: https://github.com/jdillard/sphinx-sitemap/releases
License: https://github.com/jdillard/sphinx-sitemap/blob/v2.5.1/LICENSE
Requirements: https://github.com/jdillard/sphinx-sitemap/blob/v2.5.1/setup.cfg#L7

Actions:
1. Skip py<37 and remove noarch python
2. Add `--no-deps --no-build-isolation` to script
3. Fix python pinnings in host and run
4. Add missing setuptools & wheel
5. Add dev_url
6. Add license_family
7. Add a description